### PR TITLE
Add enable module command.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -20,7 +20,6 @@
 
   <!-- Modules -->
   <property name="modules.enable" value="false" />
-  <property name="modules.list" value="link telephone" />
 
   <!-- Mysql -->
   <property name="mysql.host" value="d8.dev" />
@@ -109,6 +108,13 @@
   <!-- Enable given modules -->
   <target name="enable:modules"
           description="Enable the contrib modules.">
+    <if>
+      <not><isset property="modules.list" /></not>
+      <then>
+        <input message="Enter module name seprated by space." propertyName="modules.list"
+               defaultValue="views views_ui" />
+      </then>
+    </if>
     <phingcall target="vagrant:run">
       <!-- After some properties for inside the Vagrant host. -->
       <property name="vagrant.cmd" value="cd ${vagrant.dir}; ./bin/drush -r ${vagrant.dir}/app en -y ${modules.list}" />


### PR DESCRIPTION
This allow user to enable module using phing task. 
User can turn this option on during re-install by adding `modules.enable=true` in build.properties.
User can also customize the module list by adding `modules.list=link telephone ban` in build.properties.
