### PR TITLE
Twiddle the time sync settings for the VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,15 +54,17 @@ Vagrant.configure("2") do |config|
 
   # Virtualbox provider configuration.
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm",     :id, "--cpus",                cpus ]
-    vb.customize ["modifyvm",     :id, "--memory",              ram ]
-    vb.customize ["modifyvm",     :id, "--natdnshostresolver1", "on" ]
-    vb.customize ["modifyvm",     :id, "--natdnsproxy1",        "on" ]
-    vb.customize ["modifyvm",     :id, "--nicpromisc1",         "allow-all" ]
-    vb.customize ["modifyvm",     :id, "--nicpromisc2",         "allow-all" ]
-    vb.customize ["modifyvm",     :id, "--nictype1",            "Am79C973" ]
-    vb.customize ["modifyvm",     :id, "--nictype2",            "Am79C973" ]
-    vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1" ]
+    vb.customize ["modifyvm",             :id, "--cpus",                cpus ]
+    vb.customize ["modifyvm",             :id, "--memory",              ram ]
+    vb.customize ["modifyvm",             :id, "--natdnshostresolver1", "on" ]
+    vb.customize ["modifyvm",             :id, "--natdnsproxy1",        "on" ]
+    vb.customize ["modifyvm",             :id, "--nicpromisc1",         "allow-all" ]
+    vb.customize ["modifyvm",             :id, "--nicpromisc2",         "allow-all" ]
+    vb.customize ["modifyvm",             :id, "--nictype1",            "Am79C973" ]
+    vb.customize ["modifyvm",             :id, "--nictype2",            "Am79C973" ]
+    vb.customize ["setextradata",         :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1" ]
+    vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-on-restore", "1"]
+    vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", "1000"]
   end
 
   # Provisioners.


### PR DESCRIPTION
Make the VM reset its system clock when more than a second out of sync, rather than try to drift back slowly.