### PR TITLE
Remember last run test class

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -171,7 +171,6 @@
       <property name="vagrant.cmd" value='cd ${vagrant.dir}/app; php ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url http://d8.dev  --verbose --color --class "${test.class}"' />
     </phingcall>
     <echo file="${project.basedir}/last.test.properties" message="last.test=${test.class}" />
-    </phingcall>
   </target>
 
   <!-- Test a group -->

--- a/build.xml
+++ b/build.xml
@@ -18,6 +18,7 @@
   <property name="drupal.dir" value="${project.basedir}/app" />
   <property name="drupal.profile" value="standard" />
   <property name="drupal.url" value="http://d8.dev" />
+  <property name="last.test" value="Drupal\action\Tests\ConfigurationTest" />
 
   <!-- Modules -->
   <property name="modules.enable" value="false" />
@@ -42,6 +43,7 @@
 
   <!-- Provide overrides. -->
   <property file="build.properties" override="true" />
+  <property file="last.test.properties" override="true" />
 
   <!--         -->
   <!-- Targets -->
@@ -162,11 +164,13 @@
   <target name="simpletest:class"
           description="Test a test class using simpletest.">
     <input propertyName="test.class"
-           defaultValue="Drupal\action\Tests\ConfigurationTest"
+           defaultValue="${last.test}"
            message="Enter class name with namespace." />
     <phingcall target="vagrant:run">
       <!-- After some properties for inside the Vagrant host. -->
       <property name="vagrant.cmd" value='cd ${vagrant.dir}/app; php ./core/scripts/run-tests.sh --php `which php` --concurrency 12 --url http://d8.dev  --verbose --color --class "${test.class}"' />
+    </phingcall>
+    <echo file="${project.basedir}/last.test.properties" message="last.test=${test.class}" />
     </phingcall>
   </target>
 


### PR DESCRIPTION
When you enter a test class to run, it writes it to last.test.properties, then uses that for the default value of the prompt.