### PR TITLE
Change xdebug.max_nesting_level to 256

### DIFF
--- a/puppet/custom/drupal/templates/20-xdebug.ini.erb
+++ b/puppet/custom/drupal/templates/20-xdebug.ini.erb
@@ -1,5 +1,5 @@
 zend_extension=/usr/lib/php5/20100525+lfs/xdebug.so
-xdebug.max_nesting_level=200 ; Fixes debugging for D8.
+xdebug.max_nesting_level=256 ; Fixes debugging for D8.
 xdebug.remote_enable=1
 xdebug.remote_handler=dbgp
 xdebug.remote_mode=req


### PR DESCRIPTION
Latest Drupal 8.x asks for xdebug.max_nesting_level=256 while installing