### PR TITLE
Updated vm to pnx/lamp70

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,6 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-
 Vagrant.configure("2") do |config|
   config.vm.define 'lamp', primary: true do |lamp|
-    lamp.vm.box      = 'pnx/lamp'
+    lamp.vm.box      = 'pnx/lamp70'
     lamp.vm.hostname = 'd8.dev'
 
     # This script is a last chance for Developers to add more


### PR DESCRIPTION
As pnx/lamp70 is published at https://atlas.hashicorp.com/pnx/boxes/lamp70. I think we can use it. Fixes https://github.com/nickschuch/vd8/issues/39.

Known issues:
* XDEBUG is not enable. Use https://xdebug.org/wizard.php to fix that.
* MySQL port are not accessible form outside of the VM. Use them from the inside of VM.
